### PR TITLE
Add default rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ and [codecov-ruby](https://github.com/codecov/codecov-ruby) docs.
 ### RuboCop configuration
 
 solidus_extension_dev_tools includes a default [RuboCop](https://github.com/rubocop-hq/rubocop)
-configuration for Solidus extensions. Currently, this is based on 
+configuration for Solidus extensions. Currently, this is based on
 [Relaxed Ruby Style](https://relaxed.ruby.style) with a few customizations, but in the future we
 plan to provide custom cops to ensure your extension follows established Solidus best practices.
 
@@ -78,7 +78,7 @@ add this to your `.rubocop.yml`:
 ```yaml
 require:
   - solidus_extension_dev_tools/rubocop
-``` 
+```
 
 You can now run RuboCop with:
 
@@ -118,7 +118,7 @@ The above command will:
 * push the tag to the `upstream` remote;
 * release the new version on RubyGems.
 
-You can refer to 
+You can refer to
 [`gem release`'s documentation](https://github.com/svenfuchs/gem-release/blob/master/README.md) for
 further configuration and usage instructions.
 
@@ -135,13 +135,13 @@ task default: 'extension:specs'
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run 
-the tests. You can also run `bin/console` for an interactive prompt that will allow you to 
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run
+the tests. You can also run `bin/console` for an interactive prompt that will allow you to
 experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new 
-version, update the version number in `version.rb`, and then run `bundle exec rake release`, which 
-will create a git tag for the version, push git commits and tags, and push the `.gem` file to 
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new
+version, update the version number in `version.rb`, and then run `bundle exec rake release`, which
+will create a git tag for the version, push git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Put this in your `Rakefile`:
 ```rb
 require 'solidus_extension_dev_tools/rake_tasks'
 SolidusExtensionDevTools::RakeTasks.install
+
+task default: 'extension:specs'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ You can refer to
 [`gem release`'s documentation](https://github.com/svenfuchs/gem-release/blob/master/README.md) for
 further configuration and usage instructions.
 
+### Rake tasks
+
+Put this in your `Rakefile`:
+
+```rb
+require 'solidus_extension_dev_tools/rake_tasks'
+SolidusExtensionDevTools::RakeTasks.install
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run 

--- a/lib/solidus_extension_dev_tools/rake_tasks.rb
+++ b/lib/solidus_extension_dev_tools/rake_tasks.rb
@@ -13,11 +13,39 @@ module SolidusExtensionDevTools
 
     def initialize(root: Dir.pwd)
       @root = Pathname(root)
+      @test_app_path = @root.join(ENV['DUMMY_PATH'] || 'spec/dummy')
+      @gemspec = Bundler.load_gemspec(@root.glob("{,*}.gemspec").first)
     end
 
     attr_reader :test_app_path, :root, :gemspec
 
     def install
+      install_test_app_task
+      install_rspec_task
+    end
+
+    def install_test_app_task
+      require 'rake/clean'
+      ::CLOBBER.include test_app_path
+
+      ENV['DUMMY_PATH'] = test_app_path
+      ENV['LIB_NAME'] = gemspec.name
+      require 'spree/testing_support/extension_rake'
+    end
+
+    def install_rspec_task
+      namespace :extension do
+        require 'rspec/core/rake_task'
+        ::RSpec::Core::RakeTask.new(:specs, [] => :test_app) do |t|
+          # Ref: https://circleci.com/docs/2.0/configuration-reference#store_test_results
+          # Ref: https://github.com/solidusio/circleci-orbs-extensions#test-results-rspec
+          if ENV['TEST_RESULTS_PATH']
+            t.rspec_opts =
+              "--format progress " \
+              "--format RspecJunitFormatter  --out #{ENV['TEST_RESULTS_PATH']}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/solidus_extension_dev_tools/rake_tasks.rb
+++ b/lib/solidus_extension_dev_tools/rake_tasks.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'pathname'
+
+module SolidusExtensionDevTools
+  class RakeTasks
+    include Rake::DSL
+
+    def self.install(*args)
+      new(*args).tap(&:install)
+    end
+
+    def initialize(root: Dir.pwd)
+      @root = Pathname(root)
+    end
+
+    attr_reader :test_app_path, :root, :gemspec
+
+    def install
+    end
+  end
+end

--- a/solidus_extension_dev_tools.gemspec
+++ b/solidus_extension_dev_tools.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gem-release', '~> 2.1'
   spec.add_dependency 'github_changelog_generator', '~> 1.15'
   spec.add_dependency 'rspec-rails', '~> 4.0.0.beta3'
+  spec.add_dependency 'rspec_junit_formatter'
   spec.add_dependency 'rubocop', '~> 0.76.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'


### PR DESCRIPTION
This adds a place in which extension development related tasks can be added and properly sets up the Rspec and test_app tasks. Includes the test-results configuration required by the Solidus CircleCI ORB.

Fixes #6 