### PR TITLE
Take over the entire RuboCop configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,6 @@ add this to your `.rubocop.yml`:
 ```yaml
 require:
   - solidus_extension_dev_tools/rubocop
-
-inherit_gem:
-  solidus_extension_dev_tools: .rubocop.extension.yml
-
-AllCops:
-  Exclude:
-    - spec/dummy/**/*
-    - vendor/**/*
 ``` 
 
 You can now run RuboCop with:

--- a/lib/solidus_extension_dev_tools/rubocop.rb
+++ b/lib/solidus_extension_dev_tools/rubocop.rb
@@ -1,3 +1,16 @@
 # frozen_string_literal: true
-# This file is provided to easily provide custom cops at some point in the future without requiring
-# extensions to update their .rubocop.yml.
+
+module SolidusExtensionDevTools
+  module RuboCop
+    CONFIG_PATH = "#{__dir__}/rubocop/config.yml"
+
+    def self.inject_defaults!
+      config = ::RuboCop::ConfigLoader.load_file(CONFIG_PATH)
+      puts "configuration from #{CONFIG_PATH}" if ::RuboCop::ConfigLoader.debug?
+      config = ::RuboCop::ConfigLoader.merge_with_default(config, CONFIG_PATH, unset_nil: false)
+      ::RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
+    end
+  end
+end
+
+SolidusExtensionDevTools::RuboCop.inject_defaults!

--- a/lib/solidus_extension_dev_tools/rubocop/config.yml
+++ b/lib/solidus_extension_dev_tools/rubocop/config.yml
@@ -179,6 +179,11 @@ require:
   - rubocop-rails
   - rubocop-performance
 
+AllCops:
+  Exclude:
+    - spec/dummy/**/*
+    - vendor/**/*
+
 Metrics/BlockLength:
   Enabled: false
 


### PR DESCRIPTION
Changes our approach to providing a reusable configuration by taking over all aspects of the extension's RuboCop configuration, so that we can also specify global excludes and other options.

Implementation details are in the commit message.

Closes #4.