### PR TITLE
Import SolidusSupport::EngineExtension::Decorators feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,38 @@ $ bundle
 
 ## Usage
 
+### Engine Extensions
+
+This extension provides a module that extends `Rails::Engine` functionalities
+to support loading correctly the decorators class created into an extension
+both for development and production enviroments.
+
+To use it just include the provided module in the Engine as follow:
+
+```ruby
+module SolidusExtensionName
+  class Engine < Rails::Engine
+    engine_name 'solidus_extension_name'
+
+    include SolidusExtensionDevTools::EngineExtensions::Decorators
+    # ...
+  end
+end
+```
+
+To make it work, be sure to remove the previous implementation from the
+Engine, that should be something like:
+
+```ruby
+def self.activate
+  Dir.glob(File.join(root, "app/**/*_decorator*.rb")) do |c|
+    Rails.configuration.cache_classes ? require(c) : load(c)
+  end
+end
+
+config.to_prepare(&method(:activate).to_proc)
+```
+
 ### RSpec helpers
 
 This gem provides some useful helpers for RSpec to setup an extension's test environment easily.

--- a/lib/solidus_extension_dev_tools.rb
+++ b/lib/solidus_extension_dev_tools.rb
@@ -2,6 +2,7 @@
 
 require "solidus_support"
 require "solidus_extension_dev_tools/version"
+require "solidus_extension_dev_tools/engine_extensions"
 
 module SolidusExtensionDevTools
   class Error < StandardError; end

--- a/lib/solidus_extension_dev_tools/engine_extensions.rb
+++ b/lib/solidus_extension_dev_tools/engine_extensions.rb
@@ -1,0 +1,1 @@
+require_relative 'engine_extensions/decorators'

--- a/lib/solidus_extension_dev_tools/engine_extensions/decorators.rb
+++ b/lib/solidus_extension_dev_tools/engine_extensions/decorators.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidusExtensionDevTools
+  module EngineExtensions
+    module Decorators
+      def self.included(engine)
+        engine.class_eval do
+          extend ClassMethods
+          config.to_prepare(&method(:activate).to_proc)
+        end
+      end
+
+      module ClassMethods
+        def activate
+          base_path = root.join('app/decorators')
+
+          if Rails.respond_to?(:autoloaders)
+            # Add decorators folder to the Rails autoloader. This
+            # allows Zeitwerk to resolve decorators paths correctly,
+            # when used.
+            Dir.glob(base_path.join('*')) do |decorators_folder|
+              Rails.autoloaders.main.push_dir(decorators_folder)
+            end
+          end
+
+          # Load decorator files. This is needed since they are
+          # never explicitely referenced in the application code
+          # and won't be loaded by default. We need them to be
+          # executed anyway to extend exisiting classes.
+          Dir.glob(base_path.join('**/*.rb')) do |decorator_path|
+            Rails.configuration.cache_classes ? require(decorator_path) : load(decorator_path)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It was added in `solidus_support` with [this PR](solidus-support-pr) and  will be extracted with [this PR](extract-pr).

Ref. https://github.com/solidusio-contrib/solidus_extension_dev_tools/issues/13

[solidus-support-pr]: https://github.com/solidusio/solidus_support/pull/27
[extract-pr]: https://github.com/solidusio/solidus_support/pull/28