### PR TITLE
Add automatic stale configuration for Github 

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Adopted [Apparition](https://github.com/twalpole/apparition) as the deafult JS driver for Capybara
 - Fix window size to 1920x1080px in feature specs
+- Add the [Github configuration](https://github.com/apps/stale) to automatically mark issues as stale
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adopted [Apparition](https://github.com/twalpole/apparition) as the deafult JS driver for Capybara
 - Fix window size to 1920x1080px in feature specs
 - Add the [Github configuration](https://github.com/apps/stale) to automatically mark issues as stale
+- Add the [Github configuration](https://github.com/apps/stale) for all the new extension generated using this gem
 
 ### Changed
 

--- a/lib/solidus_extension_dev_tools/extension.rb
+++ b/lib/solidus_extension_dev_tools/extension.rb
@@ -21,6 +21,7 @@ module SolidusExtensionDevTools
       directory 'lib', "#{file_name}/lib"
       directory 'bin', "#{file_name}/bin"
       directory '.circleci', "#{file_name}/.circleci"
+      directory '.github', "#{file_name}/.github"
 
       template 'extension.gemspec.erb', "#{file_name}/#{file_name}.gemspec"
       template 'Gemfile', "#{file_name}/Gemfile"

--- a/lib/solidus_extension_dev_tools/templates/extension/.github/stale.yml
+++ b/lib/solidus_extension_dev_tools/templates/extension/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Fixes #21

## Summary

This PR permits Github to automatically mark opened issues as stale, and close it, after a defined period of the time wrote in the configuration.
All the new extension generated using this gem will have the same configuration by default.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~ (Not needed)
- [x] I have added an entry to the changelog for this change.
